### PR TITLE
fix(integral to hex): added

### DIFF
--- a/src/Time.hs
+++ b/src/Time.hs
@@ -2,9 +2,13 @@ module Time (hexTime) where
 
 import qualified Data.Time.Clock.POSIX as PT
 import Data.Hex (hex)
+import qualified Numeric as N
 
 data HexTime = HexTime String deriving Show
 
 -- get unix time in HEX format
 hexTime :: IO HexTime
-hexTime = fmap (HexTime . hex . show . round . flip (/) 30) PT.getPOSIXTime
+hexTime = fmap (HexTime . toHex . round . flip (/) 30) PT.getPOSIXTime
+
+toHex :: Integral a => a -> String
+toHex s = N.showHex (toInteger s) ""

--- a/stack.yaml
+++ b/stack.yaml
@@ -39,8 +39,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps: 
 - sandi-0.4.3
-- location:
-  git:  https://github.com/aleshgo/encdec.git 
+- git:  https://github.com/aleshgo/encdec.git 
   commit: 47921de2022b5245e7d8f2b2f45f3e6f19f0c3e4
 - time-1.8.0.4
 


### PR DESCRIPTION
@Alexey there is Integral to hex conversion, provides correct hex string
`HexTime "31405df"` however original converter add 8 ` zero's char to it (e.g. `0000000031405df`), 
may be it does have any sens :)